### PR TITLE
Incorporate quality check output into beam spot analysis

### DIFF
--- a/beamspot_analysis.C
+++ b/beamspot_analysis.C
@@ -37,8 +37,8 @@ void beamspot_analysis(
 {
   gStyle->SetOptStat(kFALSE);
   gStyle->SetPalette(55);
-  gStyle->SetCanvasDefH(999);
-  gStyle->SetCanvasDefW(666);
+  gStyle->SetCanvasDefH(6000);
+  gStyle->SetCanvasDefW(4000);
 
   TCanvas* c_qcheck = new TCanvas();
   c_qcheck->Divide(2,3);
@@ -245,7 +245,7 @@ void beamspot_analysis(
 
   if(qualitycheck != "")
     {
-      c_qcheck->Print(qualitycheck, "pdf");
+      c_qcheck->Print(qualitycheck);
     }
 
   if ( root_output != "" )

--- a/beamspot_nocompile.C
+++ b/beamspot_nocompile.C
@@ -1,10 +1,10 @@
 
 
-beamspot_nocompile( TString fname="webcam/2016_07_19/IMG_2016_07_19T09_28_26_SN_0219.JPG", TString rootname="" )
+beamspot_nocompile( TString fname="webcam/2016_07_19/IMG_2016_07_19T09_28_26_SN_0219.JPG", TString qualitycheck="",TString rootname="" )
 {
 
   gSystem->Load("beamspot_analysis_C.so");
 
-  beamspot_analysis(fname,rootname);
+  beamspot_analysis(fname,qualitycheck,rootname);
 
 }

--- a/beamspot_script.sh
+++ b/beamspot_script.sh
@@ -31,14 +31,18 @@ for FILENAME in $FILELIST; do
 current1=$(cat $CONFIGLIST | grep $FILENAME | cut -d\  -f2)
 current2=$(cat $CONFIGLIST | grep $FILENAME | cut -d\  -f3)
 
-EPSNAME=$(echo ${PNGLocale}$( echo ${FILENAME} | cut -d\/ -f4 | sed -s 's/.JPG/.pdf/g') )
-echo $EPSNAME
+PNGNAME=$(echo ${PNGLocale}$( echo ${FILENAME} | cut -d\/ -f4 | sed -s 's/.JPG/.png/g') )
+echo $PNGNAME
+PDFNAME=$(echo ${PNGLocale}$( echo ${FILENAME} | cut -d\/ -f4 | sed -s 's/.JPG/.pdf/g') )
+echo $PDFNAME
+
 #Run the image through the Beam Spot Analysis code
 
 
 #root -b -q -L beamspot_analysis.C++\(\"${FILENAME}\"\) > tempoutput.txt
-root -b -q beamspot_nocompile.C\(\"${FILENAME}\",\"${EPSNAME}\"\) > tempoutput.txt
+root -b -q beamspot_nocompile.C\(\"${FILENAME}\",\"${PNGNAME}\"\) > tempoutput.txt
 
+convert ${PNGNAME} ${PDFNAME}
 #Obtain mean and standard deviation values for x and y
 meanx=$(cat tempoutput.txt | grep "Mean x:" | cut -d: -f2)
 stdx=$(cat tempoutput.txt | grep "std x:" | cut -d: -f2)
@@ -51,4 +55,4 @@ echo "$FILEID ${current1} ${current2} ${meanx} ${stdx} ${meany} ${stdy}" >> beam
 #Done with the for loop, although this command is pretty self-explanatory
 done
 
-gs -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -sOutputFile="../Images/LiRoom_QCheck/LiRoomTest.pdf" "../Images/LiRoom_QCheck/IMG*.pdf"
+gs -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -sEPSCrop -sOutputFile=../Images/LiRoom_QCheck/LiRoomTest2.pdf ../Images/LiRoom_QCheck/IMG*.eps

--- a/beamspot_script.sh
+++ b/beamspot_script.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #A shell script to run the Beam Spot Analysis code for multiple beam spot images
 #Assign file name to output file variable
-OUTPUTFILE="BeamSpotData/beamspot_data.txt"
-
-CONFIGLIST="Currents/currents_ORoom3.txt"
+OUTPUTFILE="beamspot_data.txt"
+PNGLocale="../Images/LiRoom_QCheck/"
+CONFIGLIST="Currents/currents_shorttest.txt"
 
 #If an output file of this name already exists, remove it
 if [[ -e $OUTPUTFILE ]]; then
@@ -30,11 +30,14 @@ for FILENAME in $FILELIST; do
 #Obtain current values used to create the beam spot in the associated image file
 current1=$(cat $CONFIGLIST | grep $FILENAME | cut -d\  -f2)
 current2=$(cat $CONFIGLIST | grep $FILENAME | cut -d\  -f3)
+
+EPSNAME=$(echo ${PNGLocale}$( echo ${FILENAME} | cut -d\/ -f4 | sed -s 's/.JPG/.pdf/g') )
+echo $EPSNAME
 #Run the image through the Beam Spot Analysis code
 
 
 #root -b -q -L beamspot_analysis.C++\(\"${FILENAME}\"\) > tempoutput.txt
-root -b -q beamspot_nocompile.C\(\"${FILENAME}\"\) > tempoutput.txt
+root -b -q beamspot_nocompile.C\(\"${FILENAME}\",\"${EPSNAME}\"\) > tempoutput.txt
 
 #Obtain mean and standard deviation values for x and y
 meanx=$(cat tempoutput.txt | grep "Mean x:" | cut -d: -f2)
@@ -48,4 +51,4 @@ echo "$FILEID ${current1} ${current2} ${meanx} ${stdx} ${meany} ${stdy}" >> beam
 #Done with the for loop, although this command is pretty self-explanatory
 done
 
-
+gs -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -sOutputFile="../Images/LiRoom_QCheck/LiRoomTest.pdf" "../Images/LiRoom_QCheck/IMG*.pdf"


### PR DESCRIPTION
beamspot_analysis.C outputs a six plot canvas that acts as a quality check for the beam spot analysis.
beamspot_script.sh contains a method for outputing the quality check to a pdf document for each image and then all of these pdfs are merged into one...this feature does not work yet
beamspot_nocompile.C is appropriately edited so that it can take the pdf file name as an input